### PR TITLE
Indexer code changes for PlaceOrderV3

### DIFF
--- a/utils/instruction-types.ts
+++ b/utils/instruction-types.ts
@@ -383,6 +383,15 @@ export interface placeOrderV2 {
   clientOrderId: anchor.BN | null;
 }
 
+export interface placeOrderV3 {
+  price: anchor.BN;
+  size: anchor.BN;
+  side: Side;
+  orderType: OrderType;
+  clientOrderId: anchor.BN | null;
+  tag: String | null;
+}
+
 export interface cancelOrder {
   side: Side;
   orderId: anchor.BN;

--- a/utils/instruction-types.ts
+++ b/utils/instruction-types.ts
@@ -418,5 +418,5 @@ export interface crankEventQueue {}
 export interface rebalanceInsuranceVault {}
 
 export interface liquidate {
-  size: number;
+  size: anchor.BN;
 }

--- a/utils/transaction-parser.ts
+++ b/utils/transaction-parser.ts
@@ -237,6 +237,28 @@ function parseZetaInstruction(ix: PartiallyDecodedInstruction): Instruction {
       };
       break;
 
+    case "placeOrderV3":
+      // price: number;
+      // size: number;
+      // side: Side;
+      // orderType: orderType
+      // clientOrderId: number | undefined;
+      // tag: String | undefined;
+      let placeOrderV3Data = decodedIx.data as zetaTypes.placeOrderV3;
+      decodedIx.data = {
+        price: utils.convertNativeBNToDecimal(placeOrderV3Data.price),
+        size: utils.convertNativeLotSizeToDecimal(
+          placeOrderV3Data.size.toNumber()
+        ),
+        side: Object.keys(placeOrderV3Data.side)[0],
+        orderType: Object.keys(placeOrderV3Data.orderType)[0],
+        clientOrderId: placeOrderV3Data.clientOrderId
+          ? placeOrderV3Data.clientOrderId.toString()
+          : placeOrderV3Data.clientOrderId,
+        tag: placeOrderV3Data.tag,
+      };
+      break;
+
     case "cancelOrder":
       // side: Side;
       // orderId: number;
@@ -269,7 +291,8 @@ function parseZetaInstruction(ix: PartiallyDecodedInstruction): Instruction {
     case "cancelExpiredOrder":
       // side: Side;
       // orderId: number;
-      let cancelExpiredOrderData = decodedIx.data as zetaTypes.cancelExpiredOrder;
+      let cancelExpiredOrderData =
+        decodedIx.data as zetaTypes.cancelExpiredOrder;
       decodedIx.data = {
         side: Object.keys(cancelExpiredOrderData.side)[0],
         orderId: cancelExpiredOrderData.orderId.toString(),
@@ -289,7 +312,7 @@ function parseZetaInstruction(ix: PartiallyDecodedInstruction): Instruction {
       // size: number;
       let liquidateData = decodedIx.data as zetaTypes.liquidate;
       decodedIx.data = {
-        size: utils.convertNativeLotSizeToDecimal(liquidateData.size)
+        size: utils.convertNativeLotSizeToDecimal(liquidateData.size),
       };
       break;
   }

--- a/utils/transaction-parser.ts
+++ b/utils/transaction-parser.ts
@@ -231,9 +231,7 @@ function parseZetaInstruction(ix: PartiallyDecodedInstruction): Instruction {
         ),
         side: Object.keys(placeOrderV2Data.side)[0],
         orderType: Object.keys(placeOrderV2Data.orderType)[0],
-        clientOrderId: placeOrderV2Data.clientOrderId
-          ? placeOrderV2Data.clientOrderId.toString()
-          : placeOrderV2Data.clientOrderId,
+        clientOrderId: placeOrderV2Data.clientOrderId?.toString(),
       };
       break;
 
@@ -252,10 +250,8 @@ function parseZetaInstruction(ix: PartiallyDecodedInstruction): Instruction {
         ),
         side: Object.keys(placeOrderV3Data.side)[0],
         orderType: Object.keys(placeOrderV3Data.orderType)[0],
-        clientOrderId: placeOrderV3Data.clientOrderId
-          ? placeOrderV3Data.clientOrderId.toString()
-          : placeOrderV3Data.clientOrderId,
-        tag: placeOrderV3Data.tag,
+        clientOrderId: placeOrderV3Data.clientOrderId?.toString(),
+        tag: placeOrderV3Data?.tag,
       };
       break;
 

--- a/utils/transaction-parser.ts
+++ b/utils/transaction-parser.ts
@@ -312,7 +312,9 @@ function parseZetaInstruction(ix: PartiallyDecodedInstruction): Instruction {
       // size: number;
       let liquidateData = decodedIx.data as zetaTypes.liquidate;
       decodedIx.data = {
-        size: utils.convertNativeLotSizeToDecimal(liquidateData.size),
+        size: utils.convertNativeLotSizeToDecimal(
+          liquidateData.size.toNumber()
+        ),
       };
       break;
   }


### PR DESCRIPTION
We add PlaceOrderV3 to the DEX program here: https://github.com/zetamarkets/zeta-options/pull/416
This PR propagates those changes to the indexer, allowing us to view order tags. Tested in devnet and it's all OK, output here in "devnet verification": https://www.notion.so/sierraresearch/New-place_order-for-metadata-tagging-6837c7db11d24c0f979c1a170d22ee18

Also minor changes to properly support the full u64 of liquidate size 