### PR TITLE
Enrich liquidate instruction with LiquidationEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@solana/web3.js": "^1.18.0",
-    "@zetamarkets/sdk": "^0.13.0",
+    "@zetamarkets/sdk": "^0.14.2",
     "aws-sdk": "^2.1047.0",
     "buffer-layout": "^1.2.2",
     "date-and-time": "^2.1.0",

--- a/utils/transaction-parser.ts
+++ b/utils/transaction-parser.ts
@@ -37,12 +37,15 @@ function parseZetaInstructionAccounts(
   return namedAccounts;
 }
 
-function enrichPlaceOrder(instructions: Instruction[], events: anchor.Event[]) {
+function enrichInstructions(
+  instructions: Instruction[],
+  events: anchor.Event[]
+) {
   if (events == undefined || events.length == 0) {
     return;
   }
 
-  // We can have multiple PlaceOrders in a single transaction, so keep track of how deep we've searched
+  // We can have multiple instructions in a single transaction, so keep track of how deep we've searched
   let currentPlaceOrderInstruction = 0;
   let currentLiquidateInstruction = 0;
 
@@ -430,7 +433,7 @@ export function parseZetaTransaction(
     parseZetaInstruction(ix as PartiallyDecodedInstruction)
   );
 
-  enrichPlaceOrder(parsedInstructions, parsedEvents);
+  enrichInstructions(parsedInstructions, parsedEvents);
 
   return {
     transaction_id: tx.transaction.signatures[0],

--- a/utils/transaction-parser.ts
+++ b/utils/transaction-parser.ts
@@ -43,13 +43,14 @@ function enrichPlaceOrder(instructions: Instruction[], events: anchor.Event[]) {
   }
 
   // We can have multiple PlaceOrders in a single transaction, so keep track of how deep we've searched
-  let currentInstruction = 0;
+  let currentPlaceOrderInstruction = 0;
+  let currentLiquidateInstruction = 0;
 
   for (var event = 0; event < events.length; event++) {
     // Guaranteed to have 1 PlaceOrderEvent for each placeOrder instruction
     if (events[event].name === "PlaceOrderEvent") {
       // Find the corresponding placeOrder for a given PlaceOrderEvent
-      for (var i = currentInstruction; i < instructions.length; i++) {
+      for (var i = currentPlaceOrderInstruction; i < instructions.length; i++) {
         if (instructions[i].name.startsWith("placeOrder")) {
           let fee = events[event].data.fee as anchor.BN;
           let oraclePrice = events[event].data.oraclePrice as anchor.BN;
@@ -63,8 +64,49 @@ function enrichPlaceOrder(instructions: Instruction[], events: anchor.Event[]) {
             events[event].data.orderId.toString();
           // TODO change to use events[event].data.isTaker once the program is in mainnet
           instructions[i].instruction["isTaker"] = events[event].data.fee != 0;
-          currentInstruction = i + 1;
+          currentPlaceOrderInstruction = i + 1;
           break;
+        }
+      }
+      // Guaranteed to have 1 LiquidationEvent for each liquidate instruction
+    } else if (events[event].name == "LiquidationEvent") {
+      // Find the corresponding liquidate for a given LiquidationEvent
+      for (var i = currentLiquidateInstruction; i < instructions.length; i++) {
+        if (instructions[i].name.startsWith("liquidate")) {
+          // Enrich the liquidate Ix using data from the corresponding LiquidationEvent
+          instructions[i].instruction["liquidator_reward"] =
+            utils.convertNativeBNToDecimal(
+              events[event].data.liquidatorReward as anchor.BN
+            );
+          instructions[i].instruction["insurance_reward"] =
+            utils.convertNativeBNToDecimal(
+              events[event].data.insuranceReward as anchor.BN
+            );
+          instructions[i].instruction["cost_of_trades"] =
+            utils.convertNativeBNToDecimal(
+              events[event].data.costOfTrades as anchor.BN
+            );
+          instructions[i].instruction["size"] =
+            utils.convertNativeLotSizeToDecimal(
+              events[event].data.size as number
+            );
+          instructions[i].instruction["remaining_liquidatee_balance"] =
+            utils.convertNativeLotSizeToDecimal(
+              events[event].data.remainingLiquidateeBalance as number
+            );
+          instructions[i].instruction["remaining_liquidator_balance"] =
+            utils.convertNativeLotSizeToDecimal(
+              events[event].data.remainingLiquidatorBalance as number
+            );
+          instructions[i].instruction["mark_price"] =
+            utils.convertNativeBNToDecimal(
+              events[event].data.markPrice as anchor.BN
+            );
+          instructions[i].instruction["underlying_price"] =
+            utils.convertNativeBNToDecimal(
+              events[event].data.underlyingPrice as anchor.BN
+            );
+          currentLiquidateInstruction = i + 1;
         }
       }
     }


### PR DESCRIPTION
LiquidationEvents were recently pushed to devnet + mainnet, so we can enrich liquidate instructions as well. Tested in devnet by running a liquidation bot this morning, which sent 2 liquidate instructions:

### 1st liquidation

**SDK log**
`[LIQUIDATE] 9MqcCy1CXjFVyjrhB5riAZiHEkSHp91ZrvQD8cNX2cfv [KIND] call [STRIKE] 36 [EXPIRY] Fri Jun 03 2022 18:00:00 GMT+1000 (Australian Eastern Standard Time) [SIDE] Bid [AMOUNT] 3002644 [MAX CAPACITY WITH MARGIN] 28786822 [AVAILABLE SIZE] 3002644`

**Indexer log**
Liquidate instruction
`{ data: { size: 3002.644 }, name: 'liquidate' }`

Events
`[{"data":{"liquidatorReward":"b5c9772f","insuranceReward":"48b6fc79","costOfTrades":"0bdef67d38","size":"2dd114","remainingLiquidateeBalance":"00","remainingLiquidatorBalance":"1fad2cf863","markPrice":"46a2ff","underlyingPrice":"026bf407"},"name":"LiquidationEvent"}]`

Enriched instruction
`{"name":"liquidate","instruction":{"size":3002.644,"liquidator_reward":3049.879343,"insurance_reward":1219.951737,"cost_of_trades":50985.33612,"remaining_liquidatee_balance":0,"remaining_liquidator_balance":136049391.715,"mark_price":4.629247,"underlying_price":40.629255}`

**Transaction ID**
3ZnN7eVwrGzN1tdUdYyA5Bav277DEWz8Gue2HHE9qBE83fHMDacu4fxJpSyKnBJoh14stAPoo417psKetj3T9n3b

### 2nd liquidation (size = 0)

**SDK log**
`[LIQUIDATE] 9MqcCy1CXjFVyjrhB5riAZiHEkSHp91ZrvQD8cNX2cfv [KIND] call [STRIKE] 48 [EXPIRY] Fri Jun 03 2022 18:00:00 GMT+1000 (Australian Eastern Standard Time) [SIDE] Bid [AMOUNT] NaN [MAX CAPACITY WITH MARGIN] NaN [AVAILABLE SIZE] 5000`

**Indexer log**
Liquidate instruction
`{ data: { size: 0 }, name: 'liquidate' }`

Events
`[{"data":{"liquidatorReward":"00","insuranceReward":"00","costOfTrades":"00","size":"00","remainingLiquidateeBalance":"0178e460","remainingLiquidatorBalance":"1fad2cf863","markPrice":"00","underlyingPrice":"026b5b4b"},"name":"LiquidationEvent"}]`

Enriched instruction
`{"name":"liquidate","instruction":{"size":0,"liquidator_reward":0,"insurance_reward":0,"cost_of_trades":0,"remaining_liquidatee_balance":24700,"remaining_liquidator_balance":136049391.715,"mark_price":0,"underlying_price":40.590155}`

**Transaction ID**
4Z6AUFD9FZyy1BgFYoHmrLG7ZB3ryoXV8mjvCeJVawHkkubaWEC4cpCTMhaCgDQUUX22ok8cSD3cnM9LLeQL7A3M

